### PR TITLE
Fix for catching invalid plugin commands

### DIFF
--- a/openad/app/main.py
+++ b/openad/app/main.py
@@ -380,25 +380,26 @@ class RUNCMD(Cmd):
                     # Print
                     return output_text("".join(output), pad=1, edge=True)
 
-        # `<plugin_name_or_namespace> ?` or `? <plugin_name_or_namespace>` --> Display plugin overview.
-        if inp.lower() in self.plugin_names:
-            plugin_name, plugin_commands_organized = get_case_insensitive_key(all_plugin_commands_organized, inp)
-            plugin_namespace = self.plugin_name_ns_map.get(plugin_name.lower(), "")
-            return display_plugin_overview(self.plugins_metadata[plugin_namespace])
-        elif inp.lower() in self.plugin_namespaces:
-            plugin_namespace = inp.lower()
-            return display_plugin_overview(self.plugins_metadata[plugin_namespace])
+        if not disable_category_match:
+            # `<plugin_name_or_namespace> ?` or `? <plugin_name_or_namespace>` --> Display plugin overview.
+            if inp.lower() in self.plugin_names:
+                plugin_name, plugin_commands_organized = get_case_insensitive_key(all_plugin_commands_organized, inp)
+                plugin_namespace = self.plugin_name_ns_map.get(plugin_name.lower(), "")
+                return display_plugin_overview(self.plugins_metadata[plugin_namespace])
+            elif inp.lower() in self.plugin_namespaces:
+                plugin_namespace = inp.lower()
+                return display_plugin_overview(self.plugins_metadata[plugin_namespace])
 
-        # `<toolkit_name> ?` --> Display all toolkit commands.
-        if inp.upper() in _all_toolkits:
-            toolkit_name = inp.upper()
-            ok, toolkit = load_toolkit(toolkit_name)
-            toolkit_commands_organized = openad_help.organize_commands(toolkit.methods_help)
-            return output_text(
-                openad_help.all_commands(toolkit_commands_organized, toolkit_name=toolkit_name, cmd_pointer=self),
-                pad=2,
-                edge=True,
-            )
+            # `<toolkit_name> ?` --> Display all toolkit commands.
+            if inp.upper() in _all_toolkits:
+                toolkit_name = inp.upper()
+                ok, toolkit = load_toolkit(toolkit_name)
+                toolkit_commands_organized = openad_help.organize_commands(toolkit.methods_help)
+                return output_text(
+                    openad_help.all_commands(toolkit_commands_organized, toolkit_name=toolkit_name, cmd_pointer=self),
+                    pad=2,
+                    edge=True,
+                )
 
         # Add the current toolkit's commands to the main list of commands.
         try:
@@ -908,7 +909,17 @@ class RUNCMD(Cmd):
                     # Display error.
                     output_error(msg("err_invalid_cmd", error_msg), return_val=False)
 
-                    if show_suggestions:
+                    # Check if the part of the command that is recognized is matching a plugin namespace.
+                    # If so, we want to show all plugin commands.
+                    possible_plugin_namespace = help_ref.lower().strip()
+                    if possible_plugin_namespace in self.plugin_namespaces:
+                        output_warning(
+                            f"To see all available commands for the <reset>{possible_plugin_namespace}</reset> plugin, run <cmd>{possible_plugin_namespace} ?</cmd>",
+                            return_val=False,
+                        )
+
+                    # For all other scenarios, display a list of suggestions.
+                    elif show_suggestions:
                         if not multiple_suggestions:
                             output_text("<yellow>You may want to try:</yellow>", return_val=False)
                             pad_top = 1  # Single command should get a linebreak before and after.

--- a/openad/core/grammar.py
+++ b/openad/core/grammar.py
@@ -308,24 +308,24 @@ NOTE_TOOLKITS_SEE_ALL = "<soft>To see all available toolkits, run <cmd>list all 
 NOTE_TOOLKITS = "<soft>To learn more about toolkits, run <cmd>toolkit ?</cmd>.</soft>"
 
 
-# Toolkit overview screens (explains what, how to install, etc.)
-for tk in _all_toolkits:
-    # Note: statement creation is moved to create_statements()
-    # because they need to be appended after the toolkit command
-    # statements, otherwise `<prefix> abc` would be caught by
-    # the toolkit command `<prefix>` and cause error.
-    # statements.append(Forward(CaselessKeyword(tk))(tk))
-    grammar_help.append(
-        help_dict_create(
-            name=f"{tk} splash",
-            category="Toolkits",
-            command=tk.lower(),
-            # This description is never read. Inside main.py -> do_help()
-            # there is a clause that intercepts this command and displays
-            # the available commands for the toolkit instead.
-            description=f"Display the splash screen for the {tk} toolkit.",
-        )
-    )
+# # Toolkit overview screens (explains what, how to install, etc.)
+# for tk in _all_toolkits:
+#     # Note: statement creation is moved to create_statements()
+#     # because they need to be appended after the toolkit command
+#     # statements, otherwise `<prefix> abc` would be caught by
+#     # the toolkit command `<prefix>` and cause error.
+#     # statements.append(Forward(CaselessKeyword(tk))(tk))
+#     grammar_help.append(
+#         help_dict_create(
+#             name=f"{tk} splash",
+#             category="Toolkits",
+#             command=tk.lower(),
+#             # This description is never read. Inside main.py -> do_help()
+#             # there is a clause that intercepts this command and displays
+#             # the available commands for the toolkit instead.
+#             description=f"Display the splash screen for the {tk} toolkit.",
+#         )
+#     )
 
 # List toolkits
 statements.append(Forward(lister + toolkits("toolkits"))("list_toolkits"))


### PR DESCRIPTION
This is a fix addressing the issue where invalid plugin commands that would break the app or print unintended output.

The fix checks if the recognized part of the command matches a plugin namespace, and if it does, a hint is displayed on how to display the relevant plugin's commands. Example:

`rxn foobar`
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c521fae9-689f-494f-bafd-8d3db0131494" />

`rxn foo bar baz bax`
<img width="367" alt="image" src="https://github.com/user-attachments/assets/b5b2e69c-78a4-468f-bd58-60444b0a63e1" />

When the recognized part is matching more than just the namespace, the output behaves like elsewhere. Example:

`rxn predict foobar`
<img width="749" alt="image" src="https://github.com/user-attachments/assets/0e3664b2-ec88-4be6-8ab5-c55e62f90006" />
